### PR TITLE
fix double counting and add test

### DIFF
--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -16,6 +16,7 @@ int RiskTracker::updateRisk() {
         }
     }
     this->totalRisk += runningSum;
+    this->pendingTrades.clear();
     return 0;
 }
 

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -28,3 +28,14 @@ TEST(TradeRiskTrackerTest, TrackerZeroTest) {
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
 }
+
+TEST(TradeRiskTrackerTest, TrackerDoubleCountTest){ 
+    std::vector<Trade> trackedTrades; 
+    RiskTracker riskTracker(0, trackedTrades); 
+    EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4); 
+    riskTracker.addTrade(Trade(100, true, 1)); 
+    riskTracker.updateRisk(); 
+    EXPECT_NEAR(riskTracker.getRisk(), 0, 100); 
+    riskTracker.updateRisk(); 
+    EXPECT_NEAR(riskTracker.getRisk(), 0, 100); 
+}


### PR DESCRIPTION
The purpose of this PR is to fix a bug that was double counting pending trades. In essence, the pendingTrades vector did not get reset when running updateRisk, which caused pending trades to get counted multiple times when updating risk. Changes made were to clear the pendingTrades vector at the end of the updateRisk function in src/risktracker.cpp, as well as adding a test in tst/test_traderisktracker.cpp in order to test that case. While testing, I found that each trade is being counted every time that the risk is updated, which is probably not intended. I addressed this problem by clearing the pendingTrades vector at the end of the updateRisk function. I struggled with mac. For noobs, might want to give a rundown on git and gh cli, but maybe that’s the point of this.